### PR TITLE
Introduce two make variables:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 #---------------------------------------------------
+ifndef PYTHON_CONFIG
+  PYTHON_CONFIG = python-config
+endif
+ifndef BOOST_PYTHON_LIB
+  BOOST_PYTHON_LIB = boost_python
+endif
+
 CXXFLAGS      = -O4 -fPIC $(shell root-config --cflags) -I . \
-                          $(shell python-config --includes)
+                          $(shell $(PYTHON_CONFIG) --includes)
 CDBFLAGS      = -g -fPIC $(shell root-config --cflags) -I . \
-                         $(shell python-config --includes)
+                         $(shell $(PYTHON_CONFIG) --includes)
 LDFLAGS       = -g -Wl,--export-dynamic
 SOFLAGS       = -shared -Wl,--export-dynamic
 LD            = g++
@@ -62,7 +69,7 @@ clean:
 
 libDirac.so: $(OBJS) python_bindings.o
 	@echo "Building shared library ..."
-	@$(LD) $(SOFLAGS) -Wl,-soname,$@ $^ -o $@ -lboost_python
+	@$(LD) $(SOFLAGS) -Wl,-soname,$@ $^ -o $@ -l$(BOOST_PYTHON_LIB)
 	@echo "done"
 
 TThreeVectorRealDict.cxx: TThreeVectorReal.h TThreeVectorRealLinkDef.h


### PR DESCRIPTION
  PYTHON_CONFIG: Gives the name of the python coniguration script. Default value = "python-config".
  PYTHON_BOOST_LIB: Gives the name of the boost python library. Default value = "boost_python".

These variables allow setting these components of the makefile from the environment or the make command line. This is needed since they take on different values for different Linux distributions. If they are not set, the default values will be used. Note that the default values correspond to those used in the original version of Makefile.
